### PR TITLE
fix(cp-2388): if the pr number is not set or empty set a default value

### DIFF
--- a/.github/workflows/slack-deployment-message.yml
+++ b/.github/workflows/slack-deployment-message.yml
@@ -100,7 +100,7 @@ jobs:
           fi
 
           if [ -z $commit_pr_number ]; then
-            pull_request_slack_message_part="without PR"
+            pull_request_slack_message_part="(not part of an open PR)"
           else
             pull_request_slack_message_part="from pull request <https://github.com/${{github.repository}}/pull/${commit_pr_number}|#${commit_pr_number}>"
           fi

--- a/.github/workflows/slack-deployment-message.yml
+++ b/.github/workflows/slack-deployment-message.yml
@@ -76,9 +76,11 @@ jobs:
 
           echo "build commit_pr_number"
           commit_pr_number=$(echo $deployment_info | jq -r ".meta.githubPrId")
-          if [ "${commit_pr_number}" == "null" ]; then
-            commit_pr_number=$(echo "$commit_message" | pcregrep --only-matching=1 '^[^\n]+\(#(\d+)\)')
+          
+          if [[ "${commit_pr_number}" == "null" ]]; then
+            unset commit_pr_number 
           fi
+          
           echo "commit_pr_number="$commit_pr_number""
 
           echo "build app_name"
@@ -97,10 +99,16 @@ jobs:
             slack_channel='C033EL7UMS6'
           fi
 
+          if [ -z $commit_pr_number ]; then
+            pull_request_slack_message_part="without PR"
+          else
+            pull_request_slack_message_part="from pull request <https://github.com/${{github.repository}}/pull/${commit_pr_number}|#${commit_pr_number}>"
+          fi
+          
           echo "build slack_text"
           slack_text=$(cat <<EOF
             🚀  *${app_name}*
-            Commit <https://github.com/${{github.repository}}/commit/${{github.event.deployment.sha}}|${commit_sha_short}> by <https://github.com/${commit_author_login}|${commit_author_display_name}> from pull request <https://github.com/${{github.repository}}/pull/${commit_pr_number}|#${commit_pr_number}> was successfully deployed.
+            Commit <https://github.com/${{github.repository}}/commit/${{github.event.deployment.sha}}|${commit_sha_short}> by <https://github.com/${commit_author_login}|${commit_author_display_name}> ${pull_request_slack_message_part} was successfully deployed.
             ${commit_message}
             →  <https://${deployment_hostname}|View Deployment>
             →  <${vercel_inspector_url}|Inspect deployment on Vercel>


### PR DESCRIPTION
- The Slack notify was failing when the `commit_pr_number` wasn't set

Tests:
- [x] when PR is not created and the commit is not conventional with the ticket number, the script should not fail and should attach `without PR` to the Slack message 
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/11679005/180403029-281cbd61-9116-4b5a-ae22-b8a250723ea2.png">

- [x] when the PR is created and commit was pushed after the script should not fail and it should include the PR link in the Slack Message
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/11679005/180405220-d39f9e5b-ba57-4f3a-a171-b7387913350f.png">




