### PR TITLE
fix: Remove Semgrep container, install via pipx

### DIFF
--- a/.github/workflows/code_scanning.yml
+++ b/.github/workflows/code_scanning.yml
@@ -8,8 +8,6 @@ jobs:
   semgrep_scan:
     name: semgrep/ci
     runs-on: ubuntu-latest
-    container:
-      image: semgrep/semgrep:1.147.0
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
     permissions:
@@ -21,6 +19,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Required to scan git diff/history
+
+      - name: Install Semgrep
+        run: pipx install semgrep==1.147.0
 
       - name: Perform Semgrep Analysis
         # Run Semgrep scan to detect security issues and code quality problems, outputting SARIF format


### PR DESCRIPTION
This pull request updates how Semgrep is set up and run in the `code_scanning.yml` GitHub Actions workflow. Instead of using a container image, Semgrep is now installed via `pipx` directly in the workflow steps.

**CI/CD Workflow Updates:**

* Removed the use of the `semgrep/semgrep:1.147.0` container image for running Semgrep scans in the `semgrep_scan` job.
* Added a step to install Semgrep version 1.147.0 using `pipx` before running the scan, ensuring Semgrep is available in the workflow environment.